### PR TITLE
⬆️ flatbuffers v23.5.26

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -55,7 +55,6 @@ DerivePointerAlignment: true
 IncludeBlocks: Regroup
 IndentCaseBlocks: false
 IndentCaseLabels: false
-IndentWidth: 4
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(FLATBUFFERS_REPOSITORY
     CACHE STRING "Repository of flatbuffers"
 )
 set(FLATBUFFERS_TAG
-    "v23.3.3"
+    "v23.5.26"
     CACHE STRING "Git tag/branch of flatbuffers"
 )
 

--- a/include/flatbuffers/json_parser.h
+++ b/include/flatbuffers/json_parser.h
@@ -119,8 +119,8 @@ public:
      * \return true if json generation is a success, false otherwise.
      * You can get any error using error()
      */
-    virtual bool generateTextFromTable(
-        const void* table, std::string& output) = 0;
+    virtual bool generateTextFromTable(const void* table,
+        std::string& output) = 0;
 };
 
 /**
@@ -273,17 +273,18 @@ private:
     }
 
 public:
-    bool generateText(
-        const void* flatbuffer, std::string& output) override final
+    bool generateText(const void* flatbuffer,
+        std::string& output) override final
     {
-        return generateTextFromTable(
-            flatbuffers::GetRoot<T>(flatbuffer), output);
+        return generateTextFromTable(flatbuffers::GetRoot<T>(flatbuffer),
+            output);
     }
-    bool generateTextFromTable(
-        const void* table, std::string& output) override final
+    bool generateTextFromTable(const void* table,
+        std::string& output) override final
     {
-        return initGenerateText() && GenerateTextFromTable(*_parser, table,
-                                         T::GetFullyQualifiedName(), &output);
+        return initGenerateText() &&
+               flatbuffers::GenTextFromTable(*_parser, table,
+                   T::GetFullyQualifiedName(), &output) == nullptr;
     }
 
     static std::shared_ptr<TJsonParser<T, Types...>> make()


### PR DESCRIPTION
`GenerateTextFromTable` was renamed because it is now returning a new
value: https://github.com/google/flatbuffers/commit/950a71ab893e96147c30dd91735af6db73f72ae0

The function is later re-introduced in
https://github.com/google/flatbuffers/pull/7986 as deprecated, so let's
stick with the new function
